### PR TITLE
`bithound token` should open a web browser to the settings page for your repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,35 +5,62 @@
 [![bitHound Dependencies](https://www.bithound.io/projects/badges/f907f2c0-bfbd-11e5-b2ad-73729a2991e3/dependencies.svg)](https://www.bithound.io/github/bithound/cli.bithound.io/master/dependencies/npm)
 [![bitHound Dev Dependencies](https://www.bithound.io/projects/badges/f907f2c0-bfbd-11e5-b2ad-73729a2991e3/devDependencies.svg)](https://www.bithound.io/github/bithound/cli.bithound.io/master/dependencies/npm)
 
-## Alpha Pre-release
-
-This command line tool is currently in a closed alpha preview.  If you would like to try it out get in touch with Gord at gord@bithound.io
-
 ## Installation:
 Add the latest version of `bithound` to your package.json:
+
 ```
 npm install bithound --save-dev
 ```
 
 # Usage:
+This script `bin/bithound` provides two cli commands:
+
+  - `check (git url || repo token)` Checks bitHound for failing files or dependencies.
+  
+  - `token` Opens your browser to the repo settings page of the current project.
+  
+If you include `node_modules/.bin` in your `$PATH`, you can run this cli with:
 
 ```
-  Usage: bithound [options] [command]
-
-
-  Commands:
-
-    check [url]  Check if a sha passes bitHound analysis
-
-  Options:
-
-    -h, --help            output usage information
-    -V, --version         output the version number
-    --repo-token [token]  Unique token for private repository (provided by bitHound)
-    --branch [branch]     An optional branch argument. If not provided, the command will attempt to discover it through an env variable
-    --sha [sha]           An optional commit sha argument. If not provided, the command will attempt to discover it through an env variable
+bithound <command>
 ```
 
+Otherwise, run it with: 
+
+```
+./node_modules/.bin/bithound <command>
+```
+
+# Commands
+
+## check
+
+```
+bithound check <git url | repo token>
+```
+
+Attempts to retrieve the latest failing criteria status for the repo corresponding to the git url or unique repo token provided.
+
+You may optionally pass the specific branch and sha through the `--branch` and `--sha` options, respectively. However, this is 
+designed to work inside a CI and, as such, the `check` command will attempt to pick up the branch and sha from the CI environment variables
+when a push event is detected by the CI.
+
+If analysis is in progress, this command will poll until analysis is complete and report the results.
+
+Your repo token can be found on your repo settings page under _Integrations_ or by running `bithound token`.
+
+## token
+
+```
+bithound token
+```
+
+This command takes you to your _Integrations_ section of the repo settings page for the repo that bitHound is currently found to be
+a dependency of. Think of it as a shortcut to discovering your repo token.
+
+*Please note:* This command requires git to be installed in order to properly identify the repo remote origin.
+
+---
 [npm-url]: https://npmjs.org/package/bithound
 [npm-image]: https://img.shields.io/npm/v/bithound.svg
 

--- a/README.md
+++ b/README.md
@@ -34,12 +34,27 @@ Otherwise, run it with:
 # Commands
 
 ## check
+Attempts to retrieve the latest status of failing criteria for a repo.
+
+This command can be used to check the status of both public and private repos.
+
+For public repos, use the raw git url of the repo. It will look similar to:
+
+```
+git@github.com:bithound/cli.bithound.io.git
+```
+
+For private repos, use your repo token provided by bitHound. It will look similar to:
+
+```
+8164a970-c6bb-11e5-9058-dd9db6223fa8
+```
+
+Run the check command as follows:
 
 ```
 bithound check <git url | repo token>
 ```
-
-Attempts to retrieve the latest failing criteria status for the repo corresponding to the git url or unique repo token provided.
 
 You may optionally pass the specific branch and sha through the `--branch` and `--sha` options, respectively. However, this is 
 designed to work inside a CI and, as such, the `check` command will attempt to pick up the branch and sha from the CI environment variables
@@ -47,7 +62,7 @@ when a push event is detected by the CI.
 
 If analysis is in progress, this command will poll until analysis is complete and report the results.
 
-Your repo token can be found on your repo settings page under _Integrations_ or by running `bithound token`.
+Your repo token can be found on your repo settings page under _Integrations_ or by running `bithound token`. In addition, you may also configure your repo's failing criteria on that settings page.
 
 ## token
 

--- a/bithound.js
+++ b/bithound.js
@@ -11,4 +11,9 @@ program
   .description('Check if a sha passes bitHound analysis')
   .action(require('./commands/check'));
 
+program
+  .command('token')
+  .description('Opens your browser to the repo settings page to see your token')
+  .action(require('./commands/token'));
+
 program.parse(process.argv);

--- a/commands/token.js
+++ b/commands/token.js
@@ -1,0 +1,27 @@
+var exec = require('child_process').exec;
+var open = require('open');
+
+module.exports = function () {
+  exec('git remote show origin', { cwd: __dirname }, function (err, output) {
+    if (!match) {
+      process.stderr.write('Failed to execute git remote', err);
+      return process.exit(1);
+    }
+
+    var match = output.match(/(Fetch\ URL:\ git@(github|bitbucket).*:)(.*)(\.git)/);
+
+    if (!match) {
+      process.stderr.write('Failed to figure out git origin');
+      return process.exit(1);
+    }
+
+    var provider = match[2];
+    var fullname = match[3];
+
+    var url = ['https://bithound.io', 'settings', provider, fullname, 'integrations'].join('/');
+
+    console.log(url);
+    open(url);
+    process.exit();
+  });
+};

--- a/commands/token.js
+++ b/commands/token.js
@@ -1,24 +1,18 @@
-var exec = require('child_process').exec;
+var origin = require('git-origin-url');
 var open = require('open');
 
 module.exports = function () {
-  exec('git remote show origin', { cwd: __dirname }, function (err, output) {
-    if (!match) {
-      process.stderr.write('Failed to execute git remote', err);
+  origin(function (err, url) {
+    if (err) {
+      process.stderr.write('Failed to find git origin', err.message);
       return process.exit(1);
     }
 
-    var match = output.match(/(Fetch\ URL:\ git@(github|bitbucket).*:)(.*)(\.git)/);
-
-    if (!match) {
-      process.stderr.write('Failed to figure out git origin');
-      return process.exit(1);
-    }
-
+    var match = url.match(/(git@(github|bitbucket).*:)(.*)(\.git)/);
     var provider = match[2];
     var fullname = match[3];
 
-    var url = ['https://bithound.io', 'settings', provider, fullname, 'integrations'].join('/');
+    url = ['https://bithound.io', 'settings', provider, fullname, 'integrations'].join('/');
 
     console.log(url);
     open(url);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "async": "^1.5.2",
     "commander": "^2.8.1",
+    "git-origin-url": "^0.3.0",
     "open": "0.0.5",
     "request": "^2.67.0"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "async": "^1.5.2",
     "commander": "^2.8.1",
+    "open": "0.0.5",
     "request": "^2.67.0"
   },
   "devDependencies": {

--- a/tests/unit/token.js
+++ b/tests/unit/token.js
@@ -1,0 +1,11 @@
+var tap = require('tap');
+var exec = require('child_process').exec;
+
+tap.test('Should point to cli.bithound.io settings page', function (t) {
+  exec('node bithound token', function (err, stdout, stderr) {
+    tap.notOk(err);
+    tap.equal(stdout, 'https://www.bithound.io/settings/github/bithound/cli.bithound.io/integrations');
+    t.end();
+  });
+});
+


### PR DESCRIPTION
This is to allow a user to be able to quickly discover their private repo's token from the repo settings page.

After installing the bitHound cli, executing the command line `bithound token` will take you directly to the repo settings page for the repo that bitHound was installed for. The command uses the git origin specified on the local machine as a point of reference to figure out where to go.

- [x] Write the command
- [x] Write a basic test