### PR TITLE
encode branch names to allow for '/'s

### DIFF
--- a/commands/check.js
+++ b/commands/check.js
@@ -48,7 +48,7 @@ function commitInfo () {
   }
 
   return {
-    branch: program.branch || branch,
+    branch: encodeURIComponent(program.branch || branch),
     sha: program.sha || sha
   };
 }


### PR DESCRIPTION
To fix issues like this: https://travis-ci.org/superleap/github-issues-label-sync/jobs/143919032