### PR TITLE
travis sha fix

### DIFF
--- a/commands/check.js
+++ b/commands/check.js
@@ -23,8 +23,13 @@ function commitInfo () {
   var branch, sha;
 
   if (process.env.TRAVIS) {
-    branch = (process.env.TRAVIS_PULL_REQUEST === 'false' ? process.env.TRAVIS_BRANCH : git.branch(process.env.TRAVIS_BUILD_DIR));
-    sha = process.env.TRAVIS_COMMIT;
+    if (process.env.TRAVIS_PULL_REQUEST === 'false') {
+      branch = process.env.TRAVIS_BRANCH;
+      sha = process.env.TRAVIS_COMMIT;
+    } else {
+      branch = (process.env.TRAVIS_PULL_REQUEST === 'false' ? process.env.TRAVIS_BRANCH : git.branch(process.env.TRAVIS_BUILD_DIR));
+      sha = process.env.TRAVIS_COMMIT_RANGE.match(/\.\.\.(\b[0-9a-f]{5,40}\b)$/i)[1];
+    }
   } else if (process.env.JENKINS_URL) {
     branch = process.env.GIT_BRANCH;
     sha = process.env.GIT_COMMIT;


### PR DESCRIPTION
The travis builds were still failing after 1.5.0

### Branch behaviour:

```
$ git clone --depth=50 --branch=gils12-improve-esdoc-frontend https://github.com/superleap/github-issues-label-sync.git superleap/github-issues-label-sync
$ cd superleap/github-issues-label-sync
$ git checkout -qf 170b5d99df01f3e25ce4949bfd6b55e7e2cc3b45
```

```
TRAVIS_PR: false
RESULTING COMMIT: abcafa8808ba9ddf98aa17ee0d0700a13be75242
COMMIT RANGE: 170b5d99df01...abcafa8808ba
```

```
$ curl -L https://www.bithound.io/api/check/github/superleap/github-issues-label-sync/gils12-improve-esdoc-frontend/abcafa8808ba9ddf98aa17ee0d0700a13be75242
{"complete":true,"failing":0,"message":""}
```

### Pull request behaviour:

```
$ git clone --depth=50 https://github.com/superleap/github-issues-label-sync.git superleap/github-issues-label-sync
$ git fetch origin +refs/pull/25/merge:
$ git checkout -qf FETCH_HEAD
```

```
TRAVIS_PR: 25
RESULTING COMMIT: e05fa81ddc3d2b0d6331c7cf30c6040efc2298cf
COMMIT RANGE: 881c556ae8eb95e12aed6483a19fc4af9a31e89f...abcafa8808ba9ddf98aa17ee0d0700a13be75242
```

```
curl -L https://www.bithound.io/api/check/github/superleap/github-issues-label-sync/gils12-improve-esdoc-frontend/abcafa8808ba9ddf98aa17ee0d0700a13be75242
{"complete":true,"failing":0,"message":""}
```

The previously merged pull request was getting the branch name properly but was failing on the commit SHA as it didn't exist at the time of the merge check.
The code in this PR is checking the commit ranges now and thus should stop failing.

### Instructions to reproduce:

Given code will fail with current version (1.5.0). 

```
export TRAVIS=true &&
export TRAVIS_PULL_REQUEST=true &&
export TRAVIS_BRANCH=e05fa81ddc3d2b0d6331c7cf30c6040efc2298cf &&
export TRAVIS_COMMIT_RANGE=881c556ae8eb95e12aed6483a19fc4af9a31e89f...abcafa8808ba9ddf98aa17ee0d0700a13be75242 &&
node_modules/.bin/bithound check git@github.com:superleap/github-issues-label-sync.git
```

Load the fork to your `package.json` or `npm link` and re-running the above command works localy.

### Live travis test:

https://travis-ci.org/superleap/github-issues-label-sync/jobs/146248303 (branch)
https://travis-ci.org/superleap/github-issues-label-sync/jobs/146248311 (pull)