### PR TITLE
local checks

### DIFF
--- a/commands/check.js
+++ b/commands/check.js
@@ -51,6 +51,9 @@ function commitInfo () {
   } else if (process.env.BITBUCKET_BRANCH) {
     branch = process.env.BITBUCKET_BRANCH;
     sha = process.env.BITBUCKET_COMMIT;
+  } else {
+    branch = git.branch(process.cwd());
+    sha = git.long(process.cwd());
   }
 
   return {


### PR DESCRIPTION
### Summary

During a travis pull request the `git-rev-sync` package ensures proper branch lookup. 
The same behaviour is required in order to do local checks.
### Current behaviour

```
λ vortex [~/WebstormProjects/github-issues-label-sync] at  gils31-bithound-local-checks ✔
→ bithound check git@github.com:superleap/github-issues-label-sync.git                                   [d159c16]
Commit sha could not be determined.%
```
### Expected behaviour

```
λ vortex [~/WebstormProjects/github-issues-label-sync] at  gils31-bithound-local-checks ✔
→ ./node_modules/.bin/bithound check git@github.com:superleap/github-issues-label-sync.git               [d159c16]

```
### Live test

https://github.com/superleap/github-issues-label-sync/pull/32
